### PR TITLE
Adds "Focal Image - Wide" style to Consumer

### DIFF
--- a/ucb_focal_image_enable.module
+++ b/ucb_focal_image_enable.module
@@ -9,5 +9,6 @@ use Drupal\Core\Database\Database;
 
 function ucb_focal_image_enable_install() {
     Database::getConnection()->query("INSERT INTO `consumer__image_styles` VALUES ('consumer',0,1,1,'en',0,'focal_image_square');");
+    Database::getConnection()->query("INSERT INTO `consumer__image_styles` VALUES ('consumer',0,1,1,'en',1,'focal_image_wide');");
 }
 ?>


### PR DESCRIPTION
Enables the consumer created on site-install to access both the "focal image square" and "focal image wide" image styles and provide them via JSON:API requests. Will be needed for blocks like the `Article Feature` where users will be able to choose which image style is applied to the article display in their dynamic block. 

Testing: Consumer is found in Configuration/Web Services/Consumer

Resolves #6 

Related to: https://github.com/CuBoulder/tiamat-theme/issues/318