### PR TITLE
Adds Full Image to default consumer for JSON:API

### DIFF
--- a/ucb_focal_image_enable.module
+++ b/ucb_focal_image_enable.module
@@ -10,5 +10,5 @@ use Drupal\Core\Database\Database;
 function ucb_focal_image_enable_install() {
     Database::getConnection()->query("INSERT INTO `consumer__image_styles` VALUES ('consumer',0,1,1,'en',0,'focal_image_square');");
     Database::getConnection()->query("INSERT INTO `consumer__image_styles` VALUES ('consumer',0,1,1,'en',1,'focal_image_wide');");
+    Database::getConnection()->query("INSERT INTO `consumer__image_styles` VALUES ('consumer',0,1,1,'en',2,'large_image_style');");
 }
-?>


### PR DESCRIPTION
Changes the Issue cover image field to use the Media Library images rather than the default. This change requires creating an additional consumer in `Focal Image Enable` to use un-cropped image styles from JSON:API as well as modifying the Issue Archive build process to use that un-cropped image.

Includes:
- `tiamat-theme` => https://github.com/CuBoulder/tiamat-theme/pull/707
- `tiamat-custom-entities` =>  https://github.com/CuBoulder/tiamat-custom-entities/pull/105
- `ucb-focal-image-enable` => 

Resolves [#104 ](https://github.com/CuBoulder/tiamat-custom-entities/issues/104)